### PR TITLE
Remove RequestModel allow any string props hackfix

### DIFF
--- a/src/components/request/RequestCreateComponent.tsx
+++ b/src/components/request/RequestCreateComponent.tsx
@@ -174,9 +174,9 @@ export default function GetSupport() {
             let check = !requestObj[name]
             setRequestObj({ ...requestObj, [name]: check });
         } else {
-            let check = !requestObj[name].checked;
-            let prop = requestObj[name]
-            setRequestObj({ ...requestObj, [name]: { ...prop, checked: check } });
+            let check = !(requestObj[name as keyof RequestModel] as { checked: boolean, value: string }).checked;
+            let prop = requestObj[name as keyof RequestModel]
+            setRequestObj({ ...requestObj, [name]: { ...(prop as { checked: boolean, value: string }), checked: check } });
         }
     }
 

--- a/src/components/request/RequestListComponent.tsx
+++ b/src/components/request/RequestListComponent.tsx
@@ -22,26 +22,26 @@ const RequestListComponent = () => {
     getData();
   }, []);
 
-  let RequestLinks = {};
-  // TODO: move styling to CSS or define at bottom
+  // let RequestLinks = {};
+  // // TODO: move styling to CSS or define at bottom
   const StageButtons = stages.map(stage => {
     const fontWeight = stage.code.toUpperCase() === stageCode.toUpperCase() ? "bold" : "normal";
     return <Link key={`stage-${stage.code}`} to={`/request/list/${programCode}/${stage.code}`} style={{ padding: "0px 50px 0px 0px", fontWeight: `${fontWeight}` }}> {stage.code}</Link >
   })
-  RequestLinks = requests.filter(request => request.programCode === programCode.toUpperCase()).map((requestObj, i) => {
-    return (
-      <tr key={`requestrow-${requestObj.requestorName}-${i}`}>
-        <td>{requestObj.targetDate}</td>
-        <td>{requestObj.flexibleDate}</td>
-        <td>{requestObj.creationTs}</td>
-        <td>{requestObj.requestorName}</td>
-        <td>{requestObj.address}</td>
-        <td>{requestObj.phone}</td>
-        <td>{requestObj.email}</td>
-        <td><button>Email Blast</button></td>
-      </tr>
-    );
-  });
+  // RequestLinks = requests.filter(request => request.programCode === programCode.toUpperCase()).map((requestObj, i) => {
+  //   return (
+  //     <tr key={`requestrow-${requestObj.requestorName}-${i}`}>
+  //       <td>{requestObj.targetDate}</td>
+  //       <td>{requestObj.flexibleDate}</td>
+  //       <td>{requestObj.creationTs}</td>
+  //       <td>{requestObj.requestorName}</td>
+  //       <td>{requestObj.address}</td>
+  //       <td>{requestObj.phone}</td>
+  //       <td>{requestObj.email}</td>
+  //       <td><button>Email Blast</button></td>
+  //     </tr>
+  //   );
+  // });
 
   function addRequest() {
     history.push('/request/create');
@@ -66,7 +66,7 @@ const RequestListComponent = () => {
             <th>Email</th>
           </tr>
         </thead>
-        <tbody>{RequestLinks}</tbody>
+        {/* <tbody>{RequestLinks}</tbody> */}
       </table>
       <hr />
       <br />

--- a/src/objectModel/RequestModel.ts
+++ b/src/objectModel/RequestModel.ts
@@ -1,6 +1,6 @@
 export class RequestModel {
   // allows to access attribute using brackets, e.g. request['address']
-  [index: string]: any;
+  // [index: string]: any;
   // 1- personal properties
   name: string;
   address: string;


### PR DESCRIPTION
Commented out `[index: string]: any;` in `RequestModel` and added some temporary fixes, allowing project to still run.

Index requestObj with string type errors supressed by casting, as temp fix until RequestCreateComponent converted to Formik.

RequestListComponent accessing invalid props commented out, as temp fix until dynamic table implemented.